### PR TITLE
Replace history with CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,17 @@
+### [ver 0.0.4](https://github.com/shiraji/GradleConfirmation/releases/tag/v0.0.4)
+
+* [#9](https://github.com/shiraji/GradleConfirmation/issues/9) Added CHANGELOG.md
+
+### [ver 0.0.3](https://github.com/shiraji/GradleConfirmation/releases/tag/v0.0.3)
+
+* [#3](https://github.com/shiraji/GradleConfirmation/issues/3) Replaced showing the notification with printing the message to the console
+* [#2](https://github.com/shiraji/GradleConfirmation/issues/2) Added Github/Plugin Home Page information to plugin.xml
+
+### [ver 0.0.2](https://github.com/shiraji/GradleConfirmation/releases/tag/v0.0.2)
+
+* Changed how to store settings (PersistentStateComponent to PropertiesComponent)
+* [#1](https://github.com/shiraji/GradleConfirmation/issues/1) Added README.md
+
+### [ver 0.0.1](https://github.com/shiraji/GradleConfirmation/releases/tag/v0.0.1)
+
+* Initial release

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
-### [ver 0.0.4](https://github.com/shiraji/GradleConfirmation/releases/tag/v0.0.4)
+### [ver 1.0.0](https://github.com/shiraji/GradleConfirmation/releases/tag/v1.0.0)
 
 * [#9](https://github.com/shiraji/GradleConfirmation/issues/9) Added CHANGELOG.md
+* [#10](https://github.com/shiraji/GradleConfirmation/issues/10) Add a function that disables each Gradle Tasks
 
 ### [ver 0.0.3](https://github.com/shiraji/GradleConfirmation/releases/tag/v0.0.3)
 

--- a/META-INF/plugin.xml
+++ b/META-INF/plugin.xml
@@ -1,10 +1,8 @@
 <idea-plugin url="https://plugins.jetbrains.com/plugin/7848" version="2">
     <id>com.github.shiraji.gradleconfirmation</id>
     <name>Gradle Confirmation</name>
-    <version>0.0.3</version>
-    <vendor email="isogai.shiraji@gmail.com" url="https://github.com/shiraji">
-        Shiraji
-    </vendor>
+    <version>1.0.0</version>
+    <vendor email="isogai.shiraji@gmail.com" url="https://github.com/shiraji">Shiraji</vendor>
 
     <description><![CDATA[
         This plugin shows a confirmation dialog before executing gradle tasks.<br/><br/>
@@ -13,6 +11,11 @@
     ]]></description>
 
     <change-notes><![CDATA[
+        <p>1.0.0</p>
+        <ul>
+            <li>Add a function that disables each Gradle Tasks</li>
+        </ul>
+
         <p>0.0.3</p>
         <ul>
             <li>Replaced showing the notification with printing the message to the console</li>

--- a/README.md
+++ b/README.md
@@ -31,17 +31,7 @@ To disable this plugin, go to `Tools > uncheck Show Gradle Confirmation`
 
 ## History
 
-### ver 0.0.3
 
-Replaced showing the notification with printing the message to the console
-
-### ver 0.0.2
-
-Changed how to store settings (PersistentStateComponent to PropertiesComponent)
-
-### ver 0.0.1
-
-nitial release
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ To disable this plugin, go to `Tools > uncheck Show Gradle Confirmation`
 
 ## History
 
-
+See [CHANGELOG](https://github.com/shiraji/GradleConfirmation/blob/master/CHANGELOG.md)
 
 ## License
 


### PR DESCRIPTION
REAME.md should not have a lot of "history".
Move the whole section to CHANGELOG.md
