### PR TITLE
Added a function that disables to show the confirmation based on gradle task names

### DIFF
--- a/META-INF/plugin.xml
+++ b/META-INF/plugin.xml
@@ -1,8 +1,10 @@
-<idea-plugin version="2" url="https://plugins.jetbrains.com/plugin/7848">
+<idea-plugin url="https://plugins.jetbrains.com/plugin/7848" version="2">
     <id>com.github.shiraji.gradleconfirmation</id>
     <name>Gradle Confirmation</name>
     <version>0.0.3</version>
-    <vendor email="isogai.shiraji@gmail.com" url="https://github.com/shiraji">Shiraji</vendor>
+    <vendor email="isogai.shiraji@gmail.com" url="https://github.com/shiraji">
+        Shiraji
+    </vendor>
 
     <description><![CDATA[
         This plugin shows a confirmation dialog before executing gradle tasks.<br/><br/>
@@ -37,13 +39,14 @@
     <depends>com.intellij.modules.lang</depends>
     -->
 
-    <depends>org.jetbrains.plugins.gradle</depends>
-
     <extensions defaultExtensionNs="com.intellij">
     </extensions>
 
+    <depends>org.jetbrains.plugins.gradle</depends>
+
     <extensions defaultExtensionNs="org.jetbrains.plugins.gradle">
-        <taskManager implementation="com.github.shiraji.gradleconfirmation.task.GradleConfirmationTaskManager"/>
+        <taskManager
+            implementation="com.github.shiraji.gradleconfirmation.task.GradleConfirmationTaskManager"/>
     </extensions>
 
     <application-components>
@@ -55,11 +58,20 @@
     </project-components>
 
     <actions>
-        <action id="GradleConfirmationToggleAction"
+        <group id="GradleConfirmationActionGroup" popup="true"
+               text="Gradle Confirmation">
+            <action
                 class="com.github.shiraji.gradleconfirmation.action.GradleConfirmationToggleAction"
+                id="GradleConfirmationToggleAction"
                 text="Show Gradle Confirmation">
-            <add-to-group group-id="ToolsMenu" anchor="last"/>
-        </action>
+            </action>
+            <action
+                class="com.github.shiraji.gradleconfirmation.action.GradleConfirmationListDisableTaskNamesAction"
+                id="GradleConfirmationListDisableTaskNamesAction"
+                text="Edit Disable Tasks...">
+            </action>
+            <add-to-group anchor="last" group-id="ToolsMenu"/>
+        </group>
     </actions>
 
 </idea-plugin>

--- a/src/com/github/shiraji/gradleconfirmation/action/GradleConfirmationListDisableTaskNamesAction.java
+++ b/src/com/github/shiraji/gradleconfirmation/action/GradleConfirmationListDisableTaskNamesAction.java
@@ -1,0 +1,133 @@
+package com.github.shiraji.gradleconfirmation.action;
+
+import com.github.shiraji.gradleconfirmation.config.GradleConfirmationConfig;
+import com.github.shiraji.gradleconfirmation.view.GradleConfirmationDisableTaskListForm;
+import com.intellij.openapi.actionSystem.AnAction;
+import com.intellij.openapi.actionSystem.AnActionEvent;
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.ui.DialogWrapper;
+import com.intellij.openapi.ui.StripeTable;
+import com.intellij.ui.AnActionButton;
+import com.intellij.ui.AnActionButtonRunnable;
+import com.intellij.ui.ToolbarDecorator;
+
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.awt.BorderLayout;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.logging.Logger;
+
+import javax.swing.Action;
+import javax.swing.JComponent;
+import javax.swing.table.DefaultTableColumnModel;
+import javax.swing.table.DefaultTableModel;
+
+public class GradleConfirmationListDisableTaskNamesAction extends AnAction {
+
+    final DefaultTableModel model = new DefaultTableModel(new String[]{"Task Names"}, 0);
+    Logger mLogger = Logger.getLogger
+            (GradleConfirmationListDisableTaskNamesAction.class.getName());
+    GradleConfirmationDisableTaskListForm mGradleConfirmationDisableTaskListForm = new
+            GradleConfirmationDisableTaskListForm();
+
+    @Override
+    public void actionPerformed(AnActionEvent anActionEvent) {
+        Project project = anActionEvent.getProject();
+        initModel(project);
+        if (new GradleConfirmationDisableTaskListDialog(project).showAndGet()) {
+            saveToConfig(project);
+        }
+    }
+
+    private void initModel(Project project) {
+        clearModel();
+        addRows(project);
+    }
+
+    private void addRows(Project project) {
+        String[] disableTaskList = GradleConfirmationConfig.getDisableTaskList(project);
+        if (disableTaskList == null) {
+            return;
+        }
+
+        for (String distableTask : disableTaskList) {
+            model.addRow(new String[]{distableTask});
+        }
+    }
+
+    private void clearModel() {
+        int rowCount = model.getRowCount();
+        for (int i = 0; i < rowCount; i++) {
+            model.removeRow(0);
+        }
+    }
+
+    private void saveToConfig(Project project) {
+        List<String> taskList = new ArrayList<String>();
+        int rowCount = model.getRowCount();
+        for (int i = 0; i < rowCount; i++) {
+            String taskName = (String) model.getValueAt(i, 0);
+            if (taskName != null && taskName.length() > 0) {
+                taskList.add(taskName);
+            }
+        }
+
+        GradleConfirmationConfig.setDisableTaskList(project, taskList);
+    }
+
+    class GradleConfirmationDisableTaskListDialog extends DialogWrapper {
+        final StripeTable table = new StripeTable(model);
+
+        protected GradleConfirmationDisableTaskListDialog(@Nullable Project project) {
+            super(project);
+            init();
+            setTitle("Disable Task List - Gradle Confirmation");
+            setSize(300, 500);
+        }
+
+        @Nullable
+        @Override
+        protected JComponent createCenterPanel() {
+            ToolbarDecorator decorator = ToolbarDecorator.createDecorator(table).disableUpDownActions();
+            initDecorator(decorator);
+            initColumnWidth(table);
+            mGradleConfirmationDisableTaskListForm.mDisableTaskListPanel.add(decorator.createPanel(), BorderLayout.CENTER);
+            return mGradleConfirmationDisableTaskListForm.mRootPanel;
+        }
+
+        private void initDecorator(ToolbarDecorator decorator) {
+            decorator.setAddAction(new AnActionButtonRunnable() {
+                @Override
+                public void run(AnActionButton anActionButton) {
+                    model.addRow(new String[]{""});
+                    table.setModel(model);
+                    table.editCellAt(model.getRowCount() - 1, 0);
+                }
+            }).setRemoveAction(new AnActionButtonRunnable() {
+                @Override
+                public void run(AnActionButton anActionButton) {
+                    int[] selectedColumns = table.getSelectedRows();
+                    Arrays.sort(selectedColumns);
+                    for (int i = selectedColumns.length - 1; i >= 0; i--) {
+                        model.removeRow(selectedColumns[i]);
+                        table.setModel(model);
+                    }
+                }
+            });
+        }
+
+        private void initColumnWidth(StripeTable table) {
+            DefaultTableColumnModel columnModel = (DefaultTableColumnModel) table.getColumnModel();
+            columnModel.getColumn(0).setPreferredWidth(300);
+        }
+
+        @NotNull
+        protected Action[] createActions() {
+            return new Action[]{this.getOKAction(), this.getCancelAction()};
+        }
+
+    }
+}

--- a/src/com/github/shiraji/gradleconfirmation/config/GradleConfirmationConfig.java
+++ b/src/com/github/shiraji/gradleconfirmation/config/GradleConfirmationConfig.java
@@ -3,9 +3,14 @@ package com.github.shiraji.gradleconfirmation.config;
 import com.intellij.ide.util.PropertiesComponent;
 import com.intellij.openapi.project.Project;
 
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
 public class GradleConfirmationConfig {
 
     public static final String IS_ENABLE_CONF_KEY = "com.github.shiraji.gradleconfirmation.isenable";
+    public static final String DISABLE_TASKS_LIST_KEY = "com.github.shiraji.gradleconfirmation.config.GradleConfirmationConfig.DISABLE_TASKS_LIST_KEY";
 
     public static boolean isSelected(Project project) {
         return PropertiesComponent.getInstance(project).getBoolean(IS_ENABLE_CONF_KEY, true);
@@ -13,5 +18,51 @@ public class GradleConfirmationConfig {
 
     public static void setSelected(Project project, boolean isEnable) {
         PropertiesComponent.getInstance(project).setValue(IS_ENABLE_CONF_KEY, String.valueOf(isEnable));
+    }
+
+    public static String[] getDisableTaskList(Project project) {
+        return PropertiesComponent.getInstance(project).getValues(DISABLE_TASKS_LIST_KEY);
+    }
+
+    public static void setDisableTaskList(Project project, List<String>
+            disableTaskList) {
+        if (disableTaskList.size() > 0) {
+            setDisableTaskList(project, disableTaskList.toArray(new String[0]));
+        } else {
+            clearDisableTaskList(project);
+        }
+    }
+
+    public static void setDisableTaskList(Project project, String[]
+            disableTaskList) {
+        PropertiesComponent.getInstance(project).setValues(DISABLE_TASKS_LIST_KEY, disableTaskList);
+    }
+
+    public static void clearDisableTaskList(Project project) {
+        PropertiesComponent.getInstance(project).setValues(DISABLE_TASKS_LIST_KEY, null);
+    }
+
+    public static void addDisableTaskList(Project project, String
+            disableTaskName) {
+        String[] taskArray = getDisableTaskList(project);
+        List<String> taskList;
+        if (taskArray == null || taskArray.length <= 0) {
+            taskList = new ArrayList<String>();
+        } else {
+            taskList = new ArrayList<String>(Arrays.asList(taskArray));
+        }
+        taskList.add(disableTaskName);
+        setDisableTaskList(project, taskList.toArray(new String[0]));
+    }
+
+    public static boolean isDistableTaskList(Project project, List<String> taskList) {
+        String[] disableTaskArray = getDisableTaskList(project);
+        if (disableTaskArray == null || disableTaskArray.length < taskList
+                .size()) {
+            return false;
+        }
+        List<String> disableTaskList = new ArrayList<String>(Arrays.asList
+                (disableTaskArray));
+        return disableTaskList.containsAll(taskList);
     }
 }

--- a/src/com/github/shiraji/gradleconfirmation/task/GradleConfirmationTaskManager.java
+++ b/src/com/github/shiraji/gradleconfirmation/task/GradleConfirmationTaskManager.java
@@ -1,19 +1,23 @@
 package com.github.shiraji.gradleconfirmation.task;
 
 import com.github.shiraji.gradleconfirmation.config.GradleConfirmationConfig;
-import com.intellij.notification.Notification;
-import com.intellij.notification.NotificationType;
-import com.intellij.notification.Notifications;
 import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.externalSystem.model.ExternalSystemException;
 import com.intellij.openapi.externalSystem.model.task.ExternalSystemTaskId;
 import com.intellij.openapi.externalSystem.model.task.ExternalSystemTaskNotificationListener;
 import com.intellij.openapi.project.Project;
+
 import org.jetbrains.plugins.gradle.service.task.GradleTaskManagerExtension;
 import org.jetbrains.plugins.gradle.settings.GradleExecutionSettings;
 
-import javax.swing.JOptionPane;
+import java.util.ArrayList;
 import java.util.List;
+
+import javax.swing.Box;
+import javax.swing.JCheckBox;
+import javax.swing.JComponent;
+import javax.swing.JLabel;
+import javax.swing.JOptionPane;
 
 public class GradleConfirmationTaskManager implements GradleTaskManagerExtension {
     private static final Logger LOG = Logger.getInstance(GradleConfirmationTaskManager.class.getName());
@@ -30,16 +34,24 @@ public class GradleConfirmationTaskManager implements GradleTaskManagerExtension
         LOG.debug("executeTasks");
 
         Project project = externalSystemTaskId.findProject();
-        if (project != null && !isEnablePlugin(project)) {
+
+        if (project == null || !isEnablePlugin(project)) {
+            return START_EXECUTE;
+        }
+
+        if (isDisableTasks(project, taskNames)) {
+            showDisableMessage(externalSystemTaskId,
+                    externalSystemTaskNotificationListener);
             return START_EXECUTE;
         }
 
         String taskListNames = createTaskListNames(taskNames);
-        String questionMessage = String.format("Are you sure you want to run %s?", taskListNames);
-        int optionDialog = JOptionPane.showOptionDialog(null, questionMessage, "Gradle Confirmation",
-                JOptionPane.YES_NO_OPTION, JOptionPane.QUESTION_MESSAGE, null, new String[]{"Yes", "No"}, null);
+        JCheckBox jCheckBox = new JCheckBox(String.format("Do not show dialog for '%s'", taskNames.get(0)));
+
+        int optionDialog = showConfirmationDialog(taskNames, taskListNames, jCheckBox);
 
         if (optionDialog == JOptionPane.YES_OPTION) {
+            addToDisableList(taskNames, project, jCheckBox);
             return START_EXECUTE;
         } else {
             showCancelMessage(externalSystemTaskId, externalSystemTaskNotificationListener, taskListNames);
@@ -47,8 +59,38 @@ public class GradleConfirmationTaskManager implements GradleTaskManagerExtension
         }
     }
 
+    private int showConfirmationDialog(List<String> taskNames, String taskListNames, JCheckBox jCheckBox) {
+        String questionMessage = String.format("Are you sure you want to run %s?", taskListNames);
+        List<JComponent> componentList = new ArrayList<JComponent>();
+        componentList.add(new JLabel(questionMessage));
+        if (taskNames.size() == 1) {
+            componentList.add((JComponent) Box.createVerticalStrut(20));
+            componentList.add(jCheckBox);
+        }
+
+        return JOptionPane.showOptionDialog(null, componentList.toArray(new JComponent[0]), "Gradle Confirmation",
+                JOptionPane.YES_NO_OPTION, JOptionPane.QUESTION_MESSAGE,
+                null, new String[]{"Run", "Cancel"}, null);
+    }
+
+    private void addToDisableList(List<String> taskNames, Project project, JCheckBox jCheckBox) {
+        if (jCheckBox.isSelected()) {
+            GradleConfirmationConfig.addDisableTaskList(project, taskNames.get(0));
+        }
+    }
+
     private boolean isEnablePlugin(Project project) {
         return GradleConfirmationConfig.isSelected(project);
+    }
+
+    private boolean isDisableTasks(Project project, List<String> taskList) {
+        return GradleConfirmationConfig.isDistableTaskList(project, taskList);
+    }
+
+    private void showDisableMessage(ExternalSystemTaskId externalSystemTaskId,
+                                    ExternalSystemTaskNotificationListener externalSystemTaskNotificationListener) {
+        externalSystemTaskNotificationListener.onTaskOutput(externalSystemTaskId,
+                "To enable Gradle Confirmation dialog, go to Tools > Gradle Confirmation > Edit Disable Tasks...\n", true);
     }
 
     private void showCancelMessage(ExternalSystemTaskId externalSystemTaskId,

--- a/src/com/github/shiraji/gradleconfirmation/view/GradleConfirmationDisableTaskListForm.form
+++ b/src/com/github/shiraji/gradleconfirmation/view/GradleConfirmationDisableTaskListForm.form
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<form xmlns="http://www.intellij.com/uidesigner/form/" version="1" bind-to-class="com.github.shiraji.gradleconfirmation.view.GradleConfirmationDisableTaskListForm">
+  <grid id="27dc6" binding="mRootPanel" layout-manager="GridLayoutManager" row-count="1" column-count="1" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+    <margin top="0" left="0" bottom="0" right="0"/>
+    <constraints>
+      <xy x="20" y="20" width="500" height="400"/>
+    </constraints>
+    <properties/>
+    <border type="none"/>
+    <children>
+      <grid id="8a342" binding="mDisableTaskListPanel" layout-manager="BorderLayout" hgap="0" vgap="0">
+        <constraints>
+          <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
+        </constraints>
+        <properties/>
+        <border type="etched" title="No confirmation gradle task names"/>
+        <children/>
+      </grid>
+    </children>
+  </grid>
+</form>

--- a/src/com/github/shiraji/gradleconfirmation/view/GradleConfirmationDisableTaskListForm.java
+++ b/src/com/github/shiraji/gradleconfirmation/view/GradleConfirmationDisableTaskListForm.java
@@ -1,0 +1,8 @@
+package com.github.shiraji.gradleconfirmation.view;
+
+import javax.swing.JPanel;
+
+public class GradleConfirmationDisableTaskListForm {
+    public JPanel mDisableTaskListPanel;
+    public JPanel mRootPanel;
+}


### PR DESCRIPTION
I don't want to have a confirmation for debug build type tasks. On the other hand, I really need to have a confirmation for release build tasks. I think this plugin should provide disable functionality based on the task name.
